### PR TITLE
interfanceをTextとFileで分割

### DIFF
--- a/cmd/slack-archive-http/main.go
+++ b/cmd/slack-archive-http/main.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	"context"
+	// "context"
 	"log"
 	"net/http"
-
-	archive "github.com/ToshihitoKon/slack-archive"
+	// archive "github.com/ToshihitoKon/slack-archive"
 )
 
 func main() {
@@ -17,25 +16,25 @@ func main() {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	// ctx := context.Background()
 
-	archiveConf := &archive.Config{}
-	slackConf := archive.NewCollectorSlackConfig(archiveConf)
-	collector := archive.NewCollectorSlack(slackConf, archiveConf)
+	// archiveConf := &archive.Config{}
+	// slackConf := archive.NewCollectorSlackConfig(archiveConf)
+	// collector := archive.NewCollectorSlack(slackConf, archiveConf)
 
-	outputs, err := collector.Execute(ctx)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-
-	formatter := &archive.FormatterText{}
-	byte := formatter.Format(outputs)
-
-	exporter := &archive.ExporterFile{
-		Writer: w,
-	}
-	if err := exporter.Write(ctx, byte); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-	}
+	// outputs, err := collector.Execute(ctx)
+	// if err != nil {
+	// 	w.WriteHeader(http.StatusInternalServerError)
+	// }
+	//
+	// formatter := &archive.FormatterText{}
+	// byte := formatter.Format(outputs)
+	//
+	// exporter := &archive.ExporterFile{
+	// 	Writer: w,
+	// }
+	// if err := exporter.Write(ctx, byte); err != nil {
+	// 	w.WriteHeader(http.StatusInternalServerError)
+	// }
 	w.WriteHeader(http.StatusOK)
 }

--- a/formatter.go
+++ b/formatter.go
@@ -12,7 +12,7 @@ type FormatterText struct{}
 
 var _ FormatterInterface = (*FormatterText)(nil)
 
-func (f *FormatterText) WriteFileName(file *TempFile) string {
+func (f *FormatterText) WriteFileName(file *LocalFile) string {
 	return path.Join(fmt.Sprintf("%s_%s", file.id, file.name))
 }
 func (f *FormatterText) Format(outputs Outputs) []byte {
@@ -26,7 +26,7 @@ func (f *FormatterText) Format(outputs Outputs) []byte {
 			output.Username,
 			output.Text,
 		)
-		for _, tfile := range output.TempFiles {
+		for _, tfile := range output.LocalFiles {
 			text += fmt.Sprintf("\n(file: %s)", f.WriteFileName(tfile))
 		}
 		texts = append(texts, text)
@@ -40,7 +40,7 @@ func (f *FormatterText) Format(outputs Outputs) []byte {
 				reply.Username,
 				strings.ReplaceAll(reply.Text, "\n", "\n | "),
 			)
-			for _, tfile := range reply.TempFiles {
+			for _, tfile := range reply.LocalFiles {
 				text += fmt.Sprintf("\n | (file: %s)", f.WriteFileName(tfile))
 			}
 			texts = append(texts, text)

--- a/interface.go
+++ b/interface.go
@@ -22,15 +22,17 @@ type CollectorInterface interface {
 
 type FormatterInterface interface {
 	Format(Outputs) []byte
-	WriteFileName(*TempFile) string
+	WriteFileName(*LocalFile) string
 }
 
-type ExporterInterface interface {
+type TextExporterInterface interface {
 	Write(context.Context, []byte) error
-	WriteFiles(context.Context, []*TempFile, func(*TempFile) string) error
+}
+type FileExporterInterface interface {
+	WriteFiles(context.Context, []*LocalFile, func(*LocalFile) string) error
 }
 
-type TempFile struct {
+type LocalFile struct {
 	id        string
 	path      string
 	name      string
@@ -43,18 +45,18 @@ type Output struct {
 	Username  string    `json:"username,omitempty"`
 	Text      string    `json:"text,omitempty"`
 
-	Replies   Outputs `json:"replies,omitempty"`
-	TempFiles []*TempFile
+	Replies    Outputs `json:"replies,omitempty"`
+	LocalFiles []*LocalFile
 }
 
 type Outputs []*Output
 
-func (outputs Outputs) TempFiles() []*TempFile {
-	res := []*TempFile{}
+func (outputs Outputs) LocalFiles() []*LocalFile {
+	res := []*LocalFile{}
 	for _, output := range outputs {
-		res = append(res, output.TempFiles...)
+		res = append(res, output.LocalFiles...)
 		for _, reply := range output.Replies {
-			res = append(res, reply.TempFiles...)
+			res = append(res, reply.LocalFiles...)
 		}
 	}
 	return res

--- a/slack.go
+++ b/slack.go
@@ -296,13 +296,13 @@ func (collector *CollectorSlack) slackMessageToOutput(msg slack.Message) (*Outpu
 	text := collector.userCache.replaceAll(msg.Text)
 
 	// Attachment Files
-	files := []*TempFile{}
+	files := []*LocalFile{}
 	for _, slackFile := range msg.Files {
 		tempPath, ok := collector.tempFilePaths[slackFile.ID]
 		if !ok {
 			continue
 		}
-		f := &TempFile{
+		f := &LocalFile{
 			id:        slackFile.ID,
 			timestamp: slackFile.Timestamp.Time(),
 			name:      slackFile.Name,
@@ -312,10 +312,10 @@ func (collector *CollectorSlack) slackMessageToOutput(msg slack.Message) (*Outpu
 	}
 
 	return &Output{
-		Timestamp: timestamp,
-		Username:  displayName,
-		Text:      text,
-		TempFiles: files,
+		Timestamp:  timestamp,
+		Username:   displayName,
+		Text:       text,
+		LocalFiles: files,
 	}, nil
 }
 
@@ -351,7 +351,7 @@ func (collector *CollectorSlack) getAllFiles(ctx context.Context) error {
 }
 
 func (collector *CollectorSlack) getFileAndPutTemporaryPath(ctx context.Context, slackFile slack.File) (string, error) {
-	path := path.Join(collector.archiveConfig.TempFileDir, slackFile.ID)
+	path := path.Join(collector.archiveConfig.LocalFileDir, slackFile.ID)
 	if _, ok := collector.tempFilePaths[slackFile.ID]; ok {
 		// Already downloaded
 		return path, nil


### PR DESCRIPTION
ファイルはS3、テキストはメールみたいなフォーマットに対応するためにInterfanceを分割
両方行けるやつは両方いける

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Changed file handling terminology from 'TempFile' to 'LocalFile' for consistency and clarity.
  - Split `ExporterInterface` into `TextExporterInterface` and `FileExporterInterface` for improved code organization and readability.

- **Bug Fixes**
  - Fixed directory path usage from `TempFileDir` to `LocalFileDir`, ensuring proper file handling and storage.

- **Chores**
  - Updated method and struct names to reflect the new `LocalFile` nomenclature, enhancing code maintainability and reducing confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->