### PR TITLE
ContentTypeを取得してS3Putにわたす

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -58,6 +58,7 @@ func (e *LocalExporter) Write(ctx context.Context, data []byte) error {
 }
 
 func (e *LocalExporter) WriteFiles(ctx context.Context, files []*LocalFile) error {
+	// debug
 	if _, err := os.ReadDir(e.fileDirPath); err != nil {
 		if err := os.MkdirAll(e.fileDirPath, 0755); err != nil {
 			return err

--- a/type.go
+++ b/type.go
@@ -1,7 +1,10 @@
 package archive
 
 import (
+	"fmt"
 	"log/slog"
+	"net/http"
+	"os"
 	"time"
 )
 
@@ -23,6 +26,20 @@ type LocalFile struct {
 	path      string
 	name      string
 	timestamp time.Time
+}
+
+func (lf *LocalFile) detectContentType() (string, error) {
+	f, err := os.Open(lf.path)
+	if err != nil {
+		return "", fmt.Errorf("error os.Open %w", err)
+	}
+	// DetectContentType read first 512 bytes
+	// ref: https://pkg.go.dev/net/http#DetectContentType
+	b := make([]byte, 512, 512)
+	if _, err := f.Read(b); err != nil {
+		return "", fmt.Errorf("error os.File.Read %w", err)
+	}
+	return http.DetectContentType(b), nil
 }
 
 type Output struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic content type detection before uploading files to S3 for more accurate file handling.

- **Enhancements**
  - Improved the `putFileToS3` function to accept and utilize the content type parameter.

- **Debugging**
  - Inserted debug comments to support better tracing and understanding of operations during directory reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->